### PR TITLE
[Setfive master] Makes request headers configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sitemapper.fetch('https://wp.seantburke.com/sitemap.xml')
 
 # Options
 
-You can add options on the intial Sitemapper object when instantiating it.
+You can add options on the initial Sitemapper object when instantiating it.
 
 + `requestHeaders`: (Object) - Additional Request Headers
 + `timeout`: (Number) - Maximum timeout for a single URL

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Sitemap-parser
-[![Build Status](https://travis-ci.org/seantomburke/sitemapper.svg?branch=master)](https://travis-ci.org/seantomburke/sitemapper) 
+[![Build Status](https://travis-ci.org/seantomburke/sitemapper.svg?branch=master)](https://travis-ci.org/seantomburke/sitemapper)
 [![Monthly Downloads](https://img.shields.io/npm/dm/sitemapper.svg)](https://www.npmjs.com/package/sitemapper)
 [![npm version](https://badge.fury.io/js/sitemapper.svg)](https://badge.fury.io/js/sitemapper)
 [![GitHub license](https://img.shields.io/github/license/seantomburke/sitemapper)](https://github.com/seantomburke/sitemapper/blob/master/LICENSE)
@@ -53,6 +53,25 @@ sitemapper.timeout = 5000;
 sitemapper.fetch('https://wp.seantburke.com/sitemap.xml')
   .then(({ url, sites }) => console.log(`url:${url}`, 'sites:', sites))
   .catch(error => console.log(error));
+```
+
+# Options
+
+You can add options on the intial Sitemapper object when instantiating it.
+
++ `requestHeaders`: (Object) - Additional Request Headers
++ `timeout`: (Number) - Maximum timeout for a single URL
+
+```javascript
+
+const sitemapper = new Sitemapper({
+  url: 'https://art-works.community/sitemap.xml',
+  timeout: 15000,
+  requestHeaders: {
+    'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0'
+  }
+});
+
 ```
 
 ### Examples in ES5

--- a/lib/assets/sitemapper.js
+++ b/lib/assets/sitemapper.js
@@ -171,7 +171,6 @@ function () {
               data = _ref.data;
           // The promise resolved, remove the timeout
           clearTimeout(_this4.timeoutTable[url]);
-          console.log(error);
 
           if (error) {
             // Fail silently

--- a/lib/assets/sitemapper.js
+++ b/lib/assets/sitemapper.js
@@ -38,10 +38,13 @@ function () {
   function Sitemapper(options) {
     _classCallCheck(this, Sitemapper);
 
-    var settings = options || {};
+    var settings = options || {
+      'requestHeaders': {}
+    };
     this.url = settings.url;
     this.timeout = settings.timeout || 15000;
     this.timeoutTable = {};
+    this.requestHeaders = settings.requestHeaders;
   }
   /**
    * Gets the sites from a sitemap.xml with a given URL
@@ -94,7 +97,8 @@ function () {
         method: 'GET',
         uri: url,
         resolveWithFullResponse: true,
-        gzip: true
+        gzip: true,
+        headers: this.requestHeaders
       };
       return new Promise(function (resolve) {
         var requester = (0, _requestPromiseNative["default"])(requestOptions).then(function (response) {
@@ -113,7 +117,8 @@ function () {
             data: data
           });
         })["catch"](function (response) {
-          return resolve({
+          console.log(response);
+          resolve({
             error: response.error,
             data: {}
           });
@@ -166,6 +171,7 @@ function () {
               data = _ref.data;
           // The promise resolved, remove the timeout
           clearTimeout(_this4.timeoutTable[url]);
+          console.log(error);
 
           if (error) {
             // Fail silently

--- a/sitemapper.d.ts
+++ b/sitemapper.d.ts
@@ -6,6 +6,7 @@ export interface SitemapperResponse {
 export interface SitemapperOptions {
     url?: string;
     timeout?: number;
+    requestHeaders?: {[name: string]: string};
 }
 
 declare class Sitemapper {

--- a/src/assets/sitemapper.js
+++ b/src/assets/sitemapper.js
@@ -111,10 +111,7 @@ export default class Sitemapper {
           return xmlParse(response.body);
         })
         .then(data => resolve({ error: null, data }))
-        .catch(response => {
-          console.log(response);
-          resolve({ error: response.error, data: {} })
-        });
+        .catch(response => resolve({ error: response.error, data: {} }));
 
       this.initializeTimeout(url, requester, resolve);
     });

--- a/src/assets/sitemapper.js
+++ b/src/assets/sitemapper.js
@@ -155,8 +155,6 @@ export default class Sitemapper {
         // The promise resolved, remove the timeout
         clearTimeout(this.timeoutTable[url]);
 
-        console.log(error);
-
         if (error) {
           // Fail silently
           return resolve([]);


### PR DESCRIPTION
Addresses the issue in #49

Use with:
```
const sm = new Sitemapper({
  url: 'https://art-works.community/sitemap.xml',
  timeout: 15000, // 15 seconds,
  requestHeaders: {
    'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0'
  }
});

sm.fetch()
  .then(data => console.log(data.sites))
  .catch(error => console.log(error));
```