### PR TITLE
fix #98: fix rejectUnauthorized option value

### DIFF
--- a/src/assets/sitemapper.js
+++ b/src/assets/sitemapper.js
@@ -41,7 +41,7 @@ export default class Sitemapper {
     this.debug = settings.debug;
     this.concurrency = settings.concurrency || 10;
     this.retries = settings.retries || 0;
-    this.rejectUnauthorized = settings.rejectUnauthorized || true;
+    this.rejectUnauthorized = settings.rejectUnauthorized === false ? false : true;
   }
 
   /**


### PR DESCRIPTION
The current value for rejectUnauthorized is set in this way:

```javascript
this.rejectUnauthorized = settings.rejectUnauthorized || true;
```

but if in the constructor we pass the value `false` it will resolve in `false || true` which is true.
I've tested this change and it seems to work when using self-signed SSL certificates.

This commit will only include the src file as I don't know if to include the compiled assets.

note: in the issue #98 @AntonKrutikov suggested this change

```javascript
this.rejectUnauthorized = settings.rejectUnauthorized ?? true;
```

but it will not be transpiled correctly so I used the "old fashion" style and `npm run compile` worked correctly.