### PR TITLE
Resolves issue #133: Add option to parse lastmod and changefreq and priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can add options on the initial Sitemapper object when instantiating it.
 + `retries`: (Number) - Sets the maximum number of retries to attempt in case of an error response (e.g. 404 or Timeout). Default: 0
 + `rejectUnauthorized`: (Boolean) - If true, it will throw on invalid certificates, such as expired or self-signed ones. Default: True
 + `lastmod`: (Number) - Timestamp of the minimum lastmod value allowed for returned urls
++ `field` : (Object) - An object of fields to be returned from the sitemap. For Example: `{ loc: true, lastmod: true, changefreq: true, priority: true }`. Leaving a field out has the same effect as `field: false`. If not specified sitemapper defaults to returning the 'classic' array of urls.
 
 ```javascript
 

--- a/sitemapper.d.ts
+++ b/sitemapper.d.ts
@@ -19,6 +19,7 @@ export interface SitemapperOptions {
   retries?: number;
   timeout?: number;
   url?: string;
+  fields?: {[name: string]: boolean};
 }
 
 declare class Sitemapper {

--- a/src/assets/sitemapper.js
+++ b/src/assets/sitemapper.js
@@ -46,6 +46,7 @@ export default class Sitemapper {
     this.retries = settings.retries || 0;
     this.rejectUnauthorized =
       settings.rejectUnauthorized === false ? false : true;
+    this.fields = settings.fields || false;
   }
 
   /**
@@ -315,7 +316,20 @@ export default class Sitemapper {
 
             return modified >= this.lastmod;
           })
-          .map((site) => site.loc && site.loc[0]);
+            .map((site) => {
+              if( !this.fields) {
+                return site.loc && site.loc[0];
+              } else {
+                  let fields = {};
+                  for (const [field, active] of Object.entries(this.fields)) {
+                    if(active){
+                      fields[field] = site[field][0]
+                    }
+                  }
+                 return fields;
+              }
+            });
+
         return {
           sites,
           errors: [],

--- a/src/tests/test.ts.ts
+++ b/src/tests/test.ts.ts
@@ -55,6 +55,18 @@ describe('Sitemapper', function () {
       sitemapper.url = 1000;
       sitemapper.url.should.equal(1000);
     });
+
+    it('should construct with specific fields', () => {
+      sitemapper = new Sitemapper({
+        fields: { "loc": true,
+          "lastmod": true,
+          "priority": true,
+          "changefreq": true
+        }
+      });
+      sitemapper.fields.should.be.Object && sitemapper.fields.should.have.keys('loc', 'lastmod', 'priority', 'changefreq');
+    });
+
   });
 
   describe('fetch Method resolves sites to array', function () {
@@ -105,6 +117,33 @@ describe('Sitemapper', function () {
           console.error('Test failed');
           done(error);
         });
+    });
+
+    it('https://www.channable.com/sitemap.xml sitemaps should contain extra fields', function (done) {
+      this.timeout(30000);
+      const url = 'https://www.channable.com/sitemap.xml';
+      sitemapper = new Sitemapper({
+        fields: { "loc": true,
+          "lastmod": true,
+          "priority": true,
+          "changefreq": true
+        }
+      });
+      sitemapper.fetch(url)
+          .then(data => {
+            data.sites.should.be.Array;
+            data.url.should.equal(url);
+            data.sites.length.should.be.above(2);
+            data.sites[0].loc.should.be.String;
+            data.sites[0].lastmod.should.be.String;
+            data.sites[0].priority.should.be.String;
+            data.sites[0].changefreq.should.be.String;
+            done();
+          })
+          .catch(error => {
+            console.error('Test failed');
+            done(error);
+          });
     });
 
     it('https://www.golinks.io/sitemap.xml sitemaps should be an array', function (done) {


### PR DESCRIPTION
I needed the option to parse more than just the urls in the ourput also. Decided to add it myself and create this pull request. I've added it to the Readme and tests as well. All tests were passed.

It actually gives the user to specify the fields to be included in the output by providing `fields` ,  a new object, available in the settings/constructor. I've not limited it to lastmod, changefreq and priority because technically you are allowed to have more and other fields as well in a sitemap.xml. The `loc` can even be excluded by either leaving it out of the fields parameter or by setting it to `false`.