### PR TITLE
Resolves issue #154: Enables field parsing even when some items may not include field

### DIFF
--- a/src/assets/sitemapper.js
+++ b/src/assets/sitemapper.js
@@ -331,7 +331,7 @@ export default class Sitemapper {
               } else {
                   let fields = {};
                   for (const [field, active] of Object.entries(this.fields)) {
-                    if(active){
+                    if(active && site[field]){
                       fields[field] = site[field][0]
                     }
                   }

--- a/src/tests/test.ts.ts
+++ b/src/tests/test.ts.ts
@@ -119,9 +119,9 @@ describe('Sitemapper', function () {
         });
     });
 
-    it('https://www.channable.com/sitemap.xml sitemaps should contain extra fields', function (done) {
+    it('https://wp.seantburke.com/sitemap.xml sitemaps should contain extra fields', function (done) {
       this.timeout(30000);
-      const url = 'https://www.channable.com/sitemap.xml';
+      const url = 'https://wp.seantburke.com/sitemap.xml';
       sitemapper = new Sitemapper({
         fields: { "loc": true,
           "lastmod": true,


### PR DESCRIPTION
Link to issue that this PR resolves: Issue #154 

This pull request also updates the test so that it uses an example sitemap that is more complex and includes items that do not include the fields specified. The new test fails in the latest public release but succeeds with the code included in this pull request.

