### PR TITLE
fix(parser): ensure sitemap & url are arrays

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sitemapper",
-  "version": "3.2.19",
+  "version": "3.2.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sitemapper",
-      "version": "3.2.19",
+      "version": "3.2.20",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemapper",
-  "version": "3.2.19",
+  "version": "3.2.20",
   "description": "Parser for XML Sitemaps to be used with Robots.txt and web crawlers",
   "keywords": [
     "parse",

--- a/src/assets/sitemapper.js
+++ b/src/assets/sitemapper.js
@@ -220,7 +220,10 @@ export default class Sitemapper {
       }
 
       // Parse XML using fast-xml-parser
-      const parser = new XMLParser();
+      const parser = new XMLParser({
+        isArray: (tagName) =>
+          ['sitemap', 'url'].some((value) => value === tagName),
+      });
 
       const data = parser.parse(responseBody.toString());
 


### PR DESCRIPTION
Issue
* When only 1 `<sitemap>` or `url` node, `fast-xml-parser` does not create an array. This breaks when trying to iterate over the `sites` node.

Fix
* Added an option to the parser to force these nodes to be an array, even when only 1 element in the XML.