### PR TITLE
Update Node.js requirement from 10+ to 18+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemapper",
-  "version": "3.3.6",
+  "version": "4.0.0",
   "description": "Parser for XML Sitemaps to be used with Robots.txt and web crawlers",
   "keywords": [
     "parse",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test": "./test"
   },
   "engines": {
-    "node": ">= 10.0.0"
+    "node": ">= 18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",


### PR DESCRIPTION
## Changes

This PR updates the Node.js requirement from version 10+ to version 18+ to support modern ESLint and other tooling.

### Breaking Changes

- Drops support for Node.js versions 10-17
- Requires Node.js 18.0.0 or higher

### Why

- New ESLint v9 requires features only available in Node.js 17+
- Supporting newer Node.js versions allows us to use modern JavaScript features
- Node.js 10 reached end-of-life in April 2021
- Node.js 18 is the current LTS version with wide adoption

This change is reflected in the version bump to 4.0.0, as it's a breaking change.