### PR TITLE
feat: add support for parsing local sitemap files

### DIFF
--- a/bin/sitemapper.js
+++ b/bin/sitemapper.js
@@ -3,19 +3,23 @@
 import Sitemapper from '../lib/assets/sitemapper.js';
 
 async function main() {
-  const sitemapUrl = process.argv[2];
+  const sitemapInput = process.argv[2];
 
-  if (!sitemapUrl) {
-    console.error('Please provide a sitemap URL');
-    console.error('Usage: npx sitemapper <sitemap-url>');
+  if (!sitemapInput) {
+    console.error('Please provide a sitemap URL or file path');
+    console.error('Usage: npx sitemapper <sitemap-url-or-file-path>');
+    console.error('Examples:');
+    console.error('  npx sitemapper https://example.com/sitemap.xml');
+    console.error('  npx sitemapper ./sitemap.xml');
+    console.error('  npx sitemapper /path/to/sitemap.xml');
     process.exit(1);
   }
 
   try {
     const sitemapper = new Sitemapper();
-    const { url, sites } = await sitemapper.fetch(sitemapUrl);
+    const { url, sites } = await sitemapper.fetch(sitemapInput);
 
-    console.log('\nSitemap URL:', url);
+    console.log('\nSitemap source:', url);
     console.log('\nFound URLs:');
     sites.forEach((site, index) => {
       console.log(`${index + 1}. ${site}`);

--- a/example.js
+++ b/example.js
@@ -44,4 +44,12 @@ import Sitemapper from 'sitemapper';
   } catch (error) {
     console.log(error);
   }
+
+  // Example with local file
+  try {
+    const { url, sites } = await sitemapper.fetch('./src/tests/test-sitemap.xml');
+    console.log(`Local file: ${url}`, 'sites:', sites);
+  } catch (error) {
+    console.log('Local file error:', error);
+  }
 })();

--- a/sitemapper.d.ts
+++ b/sitemapper.d.ts
@@ -70,12 +70,14 @@ declare class Sitemapper {
   private initializeTimeout(url: string, requester: any): void;
   private crawl(url: string, retryIndex?: number): Promise<any>;
   private parse(url: string): Promise<any>;
+  private isLocalFile(input: string): boolean;
+  private parseLocalFile(filePath: string): Promise<any>;
   isExcluded(url: string): boolean;
 
   /**
-   * Gets the sites from a sitemap.xml with a given URL
+   * Gets the sites from a sitemap.xml with a given URL or local file path
    *
-   * @param url URL to the sitemap.xml file
+   * @param url URL to the sitemap.xml file or path to a local sitemap file
    */
   fetch(
     this: Sitemapper & { fields: object },

--- a/src/examples/local-file.js
+++ b/src/examples/local-file.js
@@ -1,0 +1,45 @@
+import Sitemapper from '../assets/sitemapper.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get the directory name for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Path to a local sitemap file (you can change this to your actual file)
+const localSitemapPath = path.join(__dirname, '../tests/test-sitemap.xml');
+
+console.log('Parsing local sitemap file:', localSitemapPath);
+
+// Instantiate sitemapper
+const sitemapper = new Sitemapper({
+  debug: true, // show debug logs
+});
+
+/**
+ * Async/await example of parsing a local sitemap file
+ */
+(async () => {
+  try {
+    // fetch the local file to get all sites
+    const data = await sitemapper.fetch(localSitemapPath);
+
+    console.log('\n=== Results ===');
+    console.log('File:', data.url);
+    console.log('Number of URLs found:', data.sites.length);
+    console.log('\nURLs:');
+    data.sites.forEach((site, index) => {
+      console.log(`${index + 1}. ${site}`);
+    });
+
+    if (data.errors.length > 0) {
+      console.log('\nErrors:');
+      data.errors.forEach((error, index) => {
+        console.log(`${index + 1}. ${error.message}`);
+      });
+    }
+  } catch (error) {
+    // log any errors
+    console.error('Error:', error);
+  }
+})();

--- a/src/tests/local-file.test.ts
+++ b/src/tests/local-file.test.ts
@@ -1,0 +1,220 @@
+import 'async';
+import 'assert';
+import 'should';
+import fs from 'fs';
+import path from 'path';
+import zlib from 'zlib';
+
+// Simple function to validate URLs using the URL object
+function isUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+import Sitemapper from '../../lib/assets/sitemapper.js';
+import { SitemapperResponse } from '../../sitemapper';
+let sitemapper: Sitemapper;
+
+describe('Local File Parsing', function () {
+  beforeEach(() => {
+    sitemapper = new Sitemapper();
+  });
+
+  describe('isLocalFile method', function () {
+    it('should return false for HTTP URLs', () => {
+      sitemapper.isLocalFile('http://example.com/sitemap.xml').should.be.false;
+    });
+
+    it('should return false for HTTPS URLs', () => {
+      sitemapper.isLocalFile('https://example.com/sitemap.xml').should.be.false;
+    });
+
+    it('should return false for non-existent file paths', () => {
+      sitemapper.isLocalFile('/non/existent/file.xml').should.be.false;
+    });
+
+    it('should return true for existing local files', () => {
+      const testFile = path.join(__dirname, 'test-sitemap.xml');
+      sitemapper.isLocalFile(testFile).should.be.true;
+    });
+
+    it('should return false for empty or null input', () => {
+      sitemapper.isLocalFile('').should.be.false;
+      sitemapper.isLocalFile(null as any).should.be.false;
+      sitemapper.isLocalFile(undefined as any).should.be.false;
+    });
+  });
+
+  describe('Local sitemap file parsing', function () {
+    it('should parse a local sitemap.xml file', function (done) {
+      const testFile = path.join(__dirname, 'test-sitemap.xml');
+      sitemapper
+        .fetch(testFile)
+        .then((data) => {
+          data.sites.should.be.Array;
+          data.url.should.equal(testFile);
+          data.sites.length.should.equal(3);
+          data.sites.should.containEql('https://example.com/');
+          data.sites.should.containEql('https://example.com/page1');
+          data.sites.should.containEql('https://example.com/page2');
+          data.sites.forEach((site) => {
+            isUrl(site as string).should.be.true;
+          });
+          done();
+        })
+        .catch((error) => {
+          console.error('Test failed:', error);
+          done(error);
+        });
+    });
+
+    it('should handle local sitemapindex files', function (done) {
+      const testFile = path.join(__dirname, 'test-sitemap-index.xml');
+      sitemapper
+        .fetch(testFile)
+        .then((data) => {
+          data.sites.should.be.Array;
+          data.url.should.equal(testFile);
+          // Note: This will attempt to fetch the child sitemaps as URLs
+          // which may fail, but the structure should be parsed
+          done();
+        })
+        .catch((error) => {
+          console.error('Test failed:', error);
+          done(error);
+        });
+    });
+
+    it('should work with fields option for local files', function (done) {
+      const testFile = path.join(__dirname, 'test-sitemap.xml');
+      const sitemapperWithFields = new Sitemapper({
+        fields: {
+          loc: true,
+          lastmod: true,
+          priority: true,
+          changefreq: true,
+        },
+      });
+      
+      sitemapperWithFields
+        .fetch(testFile)
+        .then((data) => {
+          data.sites.should.be.Array;
+          data.sites.length.should.equal(3);
+          
+          const firstSite = data.sites[0] as any;
+          firstSite.should.have.property('loc').which.is.a.String();
+          firstSite.should.have.property('lastmod').which.is.a.String();
+          firstSite.should.have.property('priority').which.is.a.String();
+          firstSite.should.have.property('changefreq').which.is.a.String();
+          
+          firstSite.loc.should.equal('https://example.com/');
+          firstSite.priority.should.equal('1.0');
+          firstSite.changefreq.should.equal('monthly');
+          
+          done();
+        })
+        .catch((error) => {
+          console.error('Test failed:', error);
+          done(error);
+        });
+    });
+
+    it('should handle lastmod filtering for local files', function (done) {
+      const testFile = path.join(__dirname, 'test-sitemap.xml');
+      // Set lastmod to a timestamp after 2023-01-02
+      const sitemapperWithLastmod = new Sitemapper({
+        lastmod: new Date('2023-01-02T12:00:00+00:00').getTime(),
+      });
+      
+      sitemapperWithLastmod
+        .fetch(testFile)
+        .then((data) => {
+          data.sites.should.be.Array;
+          // Should only include URLs with lastmod >= 2023-01-02T12:00:00
+          data.sites.length.should.equal(1); // Only page2 qualifies
+          data.sites.should.containEql('https://example.com/page2');
+          done();
+        })
+        .catch((error) => {
+          console.error('Test failed:', error);
+          done(error);
+        });
+    });
+
+    it('should handle exclusions for local files', function (done) {
+      const testFile = path.join(__dirname, 'test-sitemap.xml');
+      const sitemapperWithExclusions = new Sitemapper({
+        exclusions: [/page1/],
+      });
+      
+      sitemapperWithExclusions
+        .fetch(testFile)
+        .then((data) => {
+          data.sites.should.be.Array;
+          data.sites.length.should.equal(2);
+          data.sites.should.containEql('https://example.com/');
+          data.sites.should.containEql('https://example.com/page2');
+          data.sites.should.not.containEql('https://example.com/page1');
+          done();
+        })
+        .catch((error) => {
+          console.error('Test failed:', error);
+          done(error);
+        });
+    });
+
+    it('should handle non-existent local files gracefully', function (done) {
+      const nonExistentFile = path.join(__dirname, 'non-existent.xml');
+      sitemapper
+        .fetch(nonExistentFile)
+        .then((data) => {
+          data.sites.should.be.Array;
+          data.sites.length.should.equal(0);
+          data.errors.should.be.Array;
+          data.errors.length.should.be.greaterThan(0);
+          done();
+        })
+        .catch((error) => {
+          console.error('Test failed:', error);
+          done(error);
+        });
+    });
+
+    it('should handle gzipped local files', function (done) {
+      // Create a gzipped version of the test sitemap
+      const testFile = path.join(__dirname, 'test-sitemap.xml');
+      const gzippedFile = path.join(__dirname, 'test-sitemap.xml.gz');
+      
+      const content = fs.readFileSync(testFile);
+      const gzippedContent = zlib.gzipSync(content);
+      fs.writeFileSync(gzippedFile, gzippedContent);
+      
+      sitemapper
+        .fetch(gzippedFile)
+        .then((data) => {
+          data.sites.should.be.Array;
+          data.sites.length.should.equal(3);
+          data.sites.should.containEql('https://example.com/');
+          data.sites.should.containEql('https://example.com/page1');
+          data.sites.should.containEql('https://example.com/page2');
+          
+          // Clean up
+          fs.unlinkSync(gzippedFile);
+          done();
+        })
+        .catch((error) => {
+          // Clean up even on failure
+          if (fs.existsSync(gzippedFile)) {
+            fs.unlinkSync(gzippedFile);
+          }
+          console.error('Test failed:', error);
+          done(error);
+        });
+    });
+  });
+});

--- a/src/tests/test-sitemap-index.xml
+++ b/src/tests/test-sitemap-index.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap1.xml</loc>
+    <lastmod>2023-01-01T00:00:00+00:00</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap2.xml</loc>
+    <lastmod>2023-01-02T00:00:00+00:00</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/src/tests/test-sitemap.xml
+++ b/src/tests/test-sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+    <lastmod>2023-01-01T00:00:00+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://example.com/page1</loc>
+    <lastmod>2023-01-02T00:00:00+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://example.com/page2</loc>
+    <lastmod>2023-01-03T00:00:00+00:00</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
This PR implements the feature requested in issue #15 to support parsing local sitemap.xml files.

## Changes
- Added `isLocalFile()` method to detect local file paths vs URLs
- Added `parseLocalFile()` method to handle local file reading with fs module
- Modified `parse()` method to automatically route to local file parsing
- Support all existing features with local files (gzip, fields, lastmod, exclusions)
- Updated TypeScript definitions to reflect new functionality
- Enhanced CLI binary to accept local file paths with improved help text
- Added comprehensive test suite covering various local file scenarios
- Added example usage for local file parsing
- Maintained full backward compatibility with existing URL-based usage

## Testing
The implementation includes comprehensive tests that cover:
- Basic local file parsing
- Gzipped file support
- Field filtering with local files
- Lastmod filtering with local files
- URL exclusions with local files
- Error handling for non-existent files
- Sitemap index file support

Closes #15

Generated with [Claude Code](https://claude.ai/code)