### PR TITLE
(closed)

### DIFF
--- a/.agents/skills/sitemap/SKILL.md
+++ b/.agents/skills/sitemap/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: sitemap
+description: Use the `npx sitemapper` CLI to inspect XML sitemaps from the command line. Use when you need to list URLs from a `sitemap.xml` or sitemap index, find a sitemap URL from a site root, save raw CLI output, or apply the documented minimal timeout flag.
+---
+
+# Sitemap
+
+## Overview
+
+Use this skill for command-line sitemap inspection with `npx sitemapper`. Keep the scope at the outer interface: resolve the sitemap URL, run the CLI, save raw output when needed, and summarize the result from the displayed output.
+
+## Quick Start
+
+```sh
+npx sitemapper https://example.com/sitemap.xml
+```
+
+If the user explicitly wants the documented timeout form, use:
+
+```sh
+npx sitemapper https://example.com/sitemap.xml --timeout=5000
+```
+
+## Workflow
+
+1. Choose the interface.
+
+- Use `npx sitemapper <sitemap-url>` for the normal path.
+- Add `--timeout=<ms>` only when the user explicitly asks for it or a slow sitemap needs a longer wait.
+
+2. Resolve the sitemap URL.
+
+- If the user already provides a direct sitemap URL, use it as-is.
+- If the user provides only a site root, inspect `robots.txt` first, then try common paths such as `/sitemap.xml` and `/sitemap_index.xml`.
+
+3. Work with the CLI output.
+
+- The CLI prints a sitemap header and then a numbered list of URLs.
+- Treat that output as human-oriented display, not a stable machine-readable interface.
+- If the user needs a saved artifact, save the raw CLI output as-is.
+
+4. Summarize only what the command proves.
+
+- Report the exact sitemap URL you used.
+- Give a qualitative summary based on the visible output.
+- If the user asked for an artifact, return the saved path to the raw CLI output.
+
+## CLI Notes
+
+- Stay at the CLI surface. Do not load internal repo structure or implementation details unless the user explicitly asks about the package source.
+- Prefer the direct command first.
+- Treat `npx sitemapper` as a read-only inspection tool. Do not infer metadata that the CLI output does not show.
+
+## Common Requests
+
+- "List every URL in this sitemap."
+- "Find the sitemap URL for this site and inspect it."
+- "Save the CLI output to a file."
+- "Run the timeout form from the docs."
+
+## References
+
+Read [references/cli.md](references/cli.md) for CLI recipes and sitemap discovery patterns.

--- a/.agents/skills/sitemap/references/cli.md
+++ b/.agents/skills/sitemap/references/cli.md
@@ -1,0 +1,54 @@
+# Sitemap CLI Reference
+
+## Basic Usage
+
+List the URLs from a sitemap:
+
+```sh
+npx sitemapper https://example.com/sitemap.xml
+```
+
+Use the documented timeout form when the user explicitly wants it:
+
+```sh
+npx sitemapper https://example.com/sitemap.xml --timeout=5000
+```
+
+## Find The Sitemap URL
+
+If the user gives only a site root, check `robots.txt` first:
+
+```sh
+curl -sS https://example.com/robots.txt | rg -i '^sitemap:'
+```
+
+If that does not expose a sitemap URL, try common paths manually:
+
+- `https://example.com/sitemap.xml`
+- `https://example.com/sitemap_index.xml`
+
+## Output Shape
+
+The CLI prints:
+
+- the resolved sitemap URL
+- a `Found URLs:` header
+- a numbered list of URLs
+
+Treat this as human-facing output. Do not build fragile automation around the numbering or line format.
+
+## Safe Shell Patterns
+
+Save the full CLI output:
+
+```sh
+npx sitemapper https://example.com/sitemap.xml | tee /tmp/sitemap-output.txt
+```
+
+## Reporting
+
+When summarizing results, include:
+
+- the sitemap URL you inspected
+- a brief qualitative description of the output
+- a saved file path when the user asked for output handling


### PR DESCRIPTION
One benefit of using a sitemap is that it gives the agent a broader view of the pages a site explicitly exposes via the sitemap.

An AI agent can often read a single page or follow a few links on its own, but that does not always lead to complete coverage of a site's published sitemap tree.
In particular, when a site uses a `sitemapindex`, relying on the AI to inspect pages directly may result in partial traversal or missed branches.

This skill is meant to combine two complementary strengths:

- the agent can flexibly discover the sitemap entry point from signals like `robots.txt` or common sitemap paths
- `npx sitemapper` can then enumerate the sitemap tree in a reproducible way, making it less likely that URLs will be missed

## Screenshots

`$sitemap Please investigate the size of the MDN and Cloudflare Docs websites` in Codex CLI

[![Image from Gyazo](https://i.gyazo.com/b6d6f7835a33f96894331ac7f712824b.png)](https://gyazo.com/b6d6f7835a33f96894331ac7f712824b)
[![Image from Gyazo](https://i.gyazo.com/b39ea2c6fe23b9dbdc14c3b9601c294b.png)](https://gyazo.com/b39ea2c6fe23b9dbdc14c3b9601c294b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added skill documentation for XML sitemap inspection with quick start guide, workflow procedures, and optional timeout configuration
  * Added CLI reference guide covering URL discovery via robots.txt fallback, expected output structure, command patterns for URL extraction and processing, and reporting guidelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->