### PR TITLE
fix: accept both proxyAgent shapes and correct proxy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ const sitemapper = new Sitemapper({
   concurrency: 5,
   retries: 2,
   debug: true,
-  proxyAgent: new HttpsProxyAgent({
-    proxy: 'http://localhost:8080',
-  }),
+  proxyAgent: {
+    https: new HttpsProxyAgent({
+      proxy: 'http://localhost:8080',
+    }),
+  },
   requestHeaders: {
     'User-Agent': 'Mozilla/5.0 (compatible; SitemapperBot/1.0)',
   },
@@ -209,9 +211,9 @@ Sitemapper can be customized with the following options:
     </tr>
     <tr>
       <td><code>proxyAgent</code></td>
-      <td>HttpProxyAgent | HttpsProxyAgent</td>
+      <td>{ http?, https? } | HttpProxyAgent | HttpsProxyAgent</td>
       <td><code>undefined</code></td>
-      <td>Instance of <code>hpagent</code> for proxy support</td>
+      <td>Proxy support via <code>hpagent</code>. Prefer <code>got</code>'s <code>{ http, https }</code> form; a bare agent instance is wrapped by protocol for you</td>
     </tr>
     <tr>
       <td><code>exclusions</code></td>

--- a/sitemapper.d.ts
+++ b/sitemapper.d.ts
@@ -47,7 +47,14 @@ export interface SitemapperOptions {
   timeout?: number;
   url?: string;
   fields?: SitemapperFields;
-  proxyAgent?: HttpProxyAgent | HttpsProxyAgent;
+  proxyAgent?:
+    | HttpProxyAgent
+    | HttpsProxyAgent
+    | {
+        http?: HttpProxyAgent;
+        https?: HttpsProxyAgent;
+        http2?: unknown;
+      };
   exclusions?: RegExp[];
 }
 

--- a/src/assets/sitemapper.js
+++ b/src/assets/sitemapper.js
@@ -26,7 +26,7 @@ export default class Sitemapper {
    * @params {integer} [options.retries] - The maximum number of retries to attempt when crawling fails (e.g. 1 for 1 retry, 2 attempts in total)
    * @params {boolean} [options.rejectUnauthorized] - If true (default), it will throw on invalid certificates, such as expired or self-signed ones.
    * @params {lastmod} [options.lastmod] - the minimum lastmod value for urls
-   * @params {hpagent.HttpProxyAgent|hpagent.HttpsProxyAgent} [options.proxyAgent] - instance of npm "hpagent" HttpProxyAgent or HttpsProxyAgent to be passed to npm "got"
+   * @params {hpagent.HttpProxyAgent|hpagent.HttpsProxyAgent|Object} [options.proxyAgent] - a bare npm "hpagent" HttpProxyAgent/HttpsProxyAgent, or an object of the form `{ http, https }` as expected by npm "got". A bare agent is wrapped under the key matching its protocol.
    * @params {Array<RegExp>} [options.exclusions] - Array of regex patterns to exclude URLs
    *
    * @example let sitemap = new Sitemapper({
@@ -49,8 +49,44 @@ export default class Sitemapper {
     this.rejectUnauthorized =
       settings.rejectUnauthorized === false ? false : true;
     this.fields = settings.fields || false;
-    this.proxyAgent = settings.proxyAgent || {};
+    this.proxyAgent = this.normalizeProxyAgent(settings.proxyAgent);
     this.exclusions = settings.exclusions || [];
+  }
+
+  /**
+   * Normalizes the proxyAgent option into the `{ http, https }` shape that
+   * "got" expects for its `agent` option.
+   *
+   * "got" requires an object keyed by protocol and throws
+   * `Unexpected agent option: <key>` if it is handed a bare agent instance, so
+   * a lone hpagent agent is wrapped under the key matching its protocol.
+   *
+   * @private
+   * @param {Object} [proxyAgent] - a bare hpagent agent or an `{ http, https }` object
+   * @returns {Object} an object safe to pass to got's `agent` option
+   */
+  normalizeProxyAgent(proxyAgent) {
+    if (!proxyAgent) {
+      return {};
+    }
+
+    // Already in got's `{ http, https, http2 }` form.
+    if (proxyAgent.http || proxyAgent.https || proxyAgent.http2) {
+      return proxyAgent;
+    }
+
+    // A bare agent instance: pick the key from the protocol it connects with.
+    // hpagent is only a devDependency, so detect the protocol by inspecting the
+    // agent rather than with `instanceof`, which would require importing it.
+    if (typeof proxyAgent.createConnection === 'function') {
+      const isHttps =
+        proxyAgent.defaultPort === 443 ||
+        proxyAgent.protocol === 'https:' ||
+        proxyAgent.constructor?.name === 'HttpsProxyAgent';
+      return isHttps ? { https: proxyAgent } : { http: proxyAgent };
+    }
+
+    return proxyAgent;
   }
 
   /**

--- a/src/tests/coverage.test.ts
+++ b/src/tests/coverage.test.ts
@@ -1,6 +1,7 @@
 import 'async';
 import 'assert';
 import 'should';
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 
 import Sitemapper from '../../lib/assets/sitemapper.js';
 import { SitemapperResponse } from '../../sitemapper';
@@ -10,6 +11,38 @@ describe('Sitemapper Coverage Tests', function () {
 
   beforeEach(() => {
     sitemapper = new Sitemapper();
+  });
+
+  describe('proxyAgent normalization', function () {
+    it('should default to an empty object when omitted', () => {
+      new Sitemapper({}).proxyAgent.should.deepEqual({});
+    });
+
+    it("should wrap a bare HttpsProxyAgent under the 'https' key", () => {
+      const agent = new HttpsProxyAgent({ proxy: 'http://localhost:8080' });
+      const { proxyAgent } = new Sitemapper({ proxyAgent: agent });
+
+      proxyAgent.should.have.property('https', agent);
+      proxyAgent.should.not.have.property('http');
+    });
+
+    it("should wrap a bare HttpProxyAgent under the 'http' key", () => {
+      const agent = new HttpProxyAgent({ proxy: 'http://localhost:8080' });
+      const { proxyAgent } = new Sitemapper({ proxyAgent: agent });
+
+      proxyAgent.should.have.property('http', agent);
+      proxyAgent.should.not.have.property('https');
+    });
+
+    it("should pass through got's { http, https } form untouched", () => {
+      const agents = {
+        http: new HttpProxyAgent({ proxy: 'http://localhost:8080' }),
+        https: new HttpsProxyAgent({ proxy: 'http://localhost:8080' }),
+      };
+      const { proxyAgent } = new Sitemapper({ proxyAgent: agents });
+
+      proxyAgent.should.equal(agents);
+    });
   });
 
   describe('Instance properties', function () {

--- a/src/tests/type-check.ts
+++ b/src/tests/type-check.ts
@@ -28,14 +28,25 @@ async function testTypes() {
       retries: 0,
       debug: true,
       rejectUnauthorized: false,
-      proxyAgent: new HttpsProxyAgent({
-        proxy: 'http://localhost:8080',
-      }),
+      proxyAgent: {
+        https: new HttpsProxyAgent({
+          proxy: 'http://localhost:8080',
+        }),
+      },
       exclusions: [/test/],
     };
     const sitemapperWithOptions = new Sitemapper(options);
     console.log(
       `Created sitemapper with options for ${sitemapperWithOptions.url}`
+    );
+
+    // A bare agent instance is still accepted and normalized at runtime
+    const sitemapperWithBareAgent = new Sitemapper({
+      url: 'https://test.com/sitemap.xml',
+      proxyAgent: new HttpsProxyAgent({ proxy: 'http://localhost:8080' }),
+    });
+    console.log(
+      `Created sitemapper with bare agent for ${sitemapperWithBareAgent.url}`
     );
 
     // Check fetch method and return type


### PR DESCRIPTION
Fixes #186

## The problem

The README, JSDoc, and TypeScript definitions all documented passing a bare `hpagent` instance:

```javascript
proxyAgent: new HttpsProxyAgent({ proxy: 'http://localhost:8080' })
```

But `got` v13 expects its `agent` option to be an object keyed by protocol (`{ http, https, http2 }`). Its setter iterates the value's keys and rejects anything unrecognized, so a bare agent throws on the enumerable properties it inherits from `EventEmitter`:

```
RequestError: Unexpected agent option: _events
```

This happens before any request is sent — the documented proxy example could never have worked. Verified against `got` v13:

```
BARE AGENT -> RequestError: Unexpected agent option: _events
WRAPPED    -> RequestError: Bad response: 407   # reaches the proxy
```

## The fix

The issue thread suggested docs-only, on the grounds that changing the interface would be breaking. Both are addressed here, and the code change is **not** breaking: the only shape that would "break" is the bare agent, which is currently 100% non-functional, so no working caller exists to break.

`normalizeProxyAgent()` in the constructor:

- `{ http, https }` / `http2` objects pass through untouched
- a bare agent is wrapped under the key matching its protocol
- omitted stays `{}`, as before

Protocol detection inspects the instance (`defaultPort` / `protocol`) rather than using `instanceof`. `hpagent` is only a devDependency, so importing it at runtime would break installs for the majority of users who don't use a proxy.

## Docs

README example and options table, JSDoc, and `sitemapper.d.ts` now show `got`'s `{ http, https }` form as the documented shape, with the bare agent still accepted and typed.

## Testing

- 4 new unit tests covering both shapes, the pass-through case, and the default
- `type-check.ts` exercises both the wrapped and bare forms
- Full suite green: 75 passing, plus tsc, ESLint, Prettier, CSpell
- Manually confirmed a normalized agent reaches an actual connection attempt where a bare agent still dies in raw `got`, and that no-proxy fetching is unaffected (36 sites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring proxy agents separately by protocol, including HTTP and HTTPS.
  * Existing single-agent proxy configurations remain supported.
  * Updated TypeScript definitions to reflect the expanded proxy configuration options.

* **Documentation**
  * Updated the Advanced Proxy example and configuration reference with the new object-based format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->